### PR TITLE
Unset RUSTFLAGS when building sysroot

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -76,6 +76,7 @@ fn build_crate(
 
     let mut cmd = Command::new("cargo");
     cmd.env_remove("CARGO_TARGET_DIR");
+    cmd.env_remove("RUSTFLAGS");
     cmd.env("__CARGO_DEFAULT_LIB_METADATA", "XARGO");
 
     // As of rust-lang/cargo#4788 Cargo invokes rustc with a changed "current directory" so


### PR DESCRIPTION
Fixes #4 

@qqwa Could you try whether this fixes your problem? You can install this version through:

```
cargo install --git https://github.com/rust-osdev/cargo-xbuild.git --branch unset-rustflags --force
```