### PR TITLE
Escape spaces in rustflags

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -45,7 +45,7 @@ impl Rustflags {
     pub fn for_xargo(&self, home: &Home) -> String {
         let mut flags = self.flags.clone();
         flags.push("--sysroot".to_owned());
-        flags.push(home.display().to_string());
+        flags.push(util::escape_argument_spaces(format!("{}", home.display())));
         flags.join(" ")
     }
 }

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -105,7 +105,7 @@ fn build_crate(
         }
     }
     cmd.arg("--manifest-path");
-    cmd.arg(td.join("Cargo.toml"));
+    cmd.arg(util::escape_argument_spaces(td.join("Cargo.toml").to_str().expect("This path doesn't contain valid UTF-8 characters")));
     cmd.args(&["--target", cmode.orig_triple()]);
 
     if verbose {

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -105,7 +105,7 @@ fn build_crate(
         }
     }
     cmd.arg("--manifest-path");
-    cmd.arg(util::escape_argument_spaces(td.join("Cargo.toml").to_str().expect("This path doesn't contain valid UTF-8 characters")));
+    cmd.arg(td.join("Cargo.toml"));
     cmd.args(&["--target", cmode.orig_triple()]);
 
     if verbose {

--- a/src/util.rs
+++ b/src/util.rs
@@ -101,12 +101,23 @@ pub fn write(path: &Path, contents: &str) -> Result<()> {
         .chain_err(|| format!("couldn't write to {}", p))
 }
 
+/// Escapes spaces (` `) in the given input with `%20` or does nothing. Then
+/// it returns the processed string.
+/// ### Windows Only
+/// Doesn't do anything on non-windows systems because escaped output
+/// (containing `\ `) is still treated as two arguments because of the
+/// remaining space character.
 pub fn escape_argument_spaces<S: Into<String>>(arg: S) -> String {
     #[cfg(target_os = "windows")]
     let escaped = arg.into().replace(" ", "%20");
 
     #[cfg(not(target_os = "windows"))]
+    let escaped = arg.into();
+    // Doesn't work because there's still a space character in the string
+    // and it's still interpreted as a separation between two arguments.
+    /*
     let escaped = arg.into().replace(" ", "\\ ");
+    */
 
     escaped
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -100,3 +100,13 @@ pub fn write(path: &Path, contents: &str) -> Result<()> {
         .write_all(contents.as_bytes())
         .chain_err(|| format!("couldn't write to {}", p))
 }
+
+pub fn escape_argument_spaces<S: Into<String>>(arg: S) -> String {
+    #[cfg(target_os = "windows")]
+    let escaped = arg.into().replace(" ", "%20");
+
+    #[cfg(not(target_os = "windows"))]
+    let escaped = arg.into().replace(" ", "\\ ");
+
+    escaped
+}


### PR DESCRIPTION
This is a PR originally filed by @AxelMontini  for `xargo`: https://github.com/japaric/xargo/pull/221

Below the originial PR description:

---

Fixes an error on windows where paths with whitespaces don't get escaped at all, causing the error error: multiple input filenames provided. In my case it happens because my Windows username is "Axel Montini" and xargo doesn't like the space in the middle.
This commit adds a function in utils to escape a string and replace spaces with %20 on windows or \ on other operative systems.
I haven't tested this on a Unix machine, but it seems to work on windows.