### PR TITLE
Error when sysroot contains spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Error when sysroot contains spaces ([#32](https://github.com/rust-osdev/cargo-xbuild/pull/32))
+
 ## [v0.5.9] - 2019-05-24
 
 - Make backtraces optional through a new opt-in `backtrace` feature. This removes the dependency on `cc` by default, which has special compile-time requirements.

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -45,7 +45,7 @@ impl Rustflags {
     pub fn for_xargo(&self, home: &Home) -> String {
         let mut flags = self.flags.clone();
         flags.push("--sysroot".to_owned());
-        flags.push(util::escape_argument_spaces(format!("{}", home.display())));
+        flags.push(format!("{}", home.display()));
         flags.join(" ")
     }
 }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -42,11 +42,19 @@ impl Rustflags {
     }
 
     /// Stringifies these flags for Xargo consumption
-    pub fn for_xargo(&self, home: &Home) -> String {
+    pub fn for_xargo(&self, home: &Home) -> Result<String> {
+        let sysroot = format!("{}", home.display());
+        if env::var_os("XBUILD_ALLOW_SYSROOT_SPACES").is_none() && sysroot.contains(" ") {
+            return Err(format!("Sysroot must not contain spaces!\n\
+            See issue https://github.com/rust-lang/cargo/issues/6139\n\n\
+            The sysroot is `{}`.\n\n\
+            To override this error, you can set the `XBUILD_ALLOW_SYSROOT_SPACES`\
+            environment variable.", sysroot).into());
+        }
         let mut flags = self.flags.clone();
         flags.push("--sysroot".to_owned());
-        flags.push(format!("{}", home.display()));
-        flags.join(" ")
+        flags.push(sysroot);
+        Ok(flags.join(" "))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -99,24 +99,3 @@ pub fn write(path: &Path, contents: &str) -> Result<()> {
         .write_all(contents.as_bytes())
         .chain_err(|| format!("couldn't write to {}", p))
 }
-
-/// Escapes spaces (` `) in the given input with `%20` or does nothing. Then
-/// it returns the processed string.
-/// ### Windows Only
-/// Doesn't do anything on non-windows systems because escaped output
-/// (containing `\ `) is still treated as two arguments because of the
-/// remaining space character.
-pub fn escape_argument_spaces<S: Into<String>>(arg: S) -> String {
-    #[cfg(target_os = "windows")]
-    let escaped = arg.into().replace(" ", "%20");
-
-    #[cfg(not(target_os = "windows"))]
-    let escaped = arg.into();
-    // Doesn't work because there's still a space character in the string
-    // and it's still interpreted as a separation between two arguments.
-    /*
-    let escaped = arg.into().replace(" ", "\\ ");
-    */
-
-    escaped
-}

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -28,7 +28,7 @@ pub fn run(
     cmd.arg(command_name);
     cmd.args(args.all());
 
-    let flags = rustflags.for_xargo(home);
+    let flags = rustflags.for_xargo(home)?;
     if verbose {
         writeln!(io::stderr(), "+ RUSTFLAGS={:?}", flags).ok();
     }


### PR DESCRIPTION
A sysroot with spaces does not work because of https://github.com/rust-lang/cargo/issues/6139. This PR adds a special error message for this case to prevent confusion. The error can be overridden by setting the `XBULD_ALLOW_SYSROOT_SPACES` environment variable.