### PR TITLE
Add a `XBUILD_SYSROOT_PATH` environment variable to override sysroot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Error when sysroot contains spaces ([#32](https://github.com/rust-osdev/cargo-xbuild/pull/32))
+- Allow overriding the sysroot path through a `XBUILD_SYSROOT_PATH` environment variable ([#33](https://github.com/rust-osdev/cargo-xbuild/pull/33))
 
 ## [v0.5.9] - 2019-05-24
 

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -43,7 +43,11 @@ impl Rustflags {
 
     /// Stringifies these flags for Xargo consumption
     pub fn for_xargo(&self, home: &Home) -> Result<String> {
-        let sysroot = format!("{}", home.display());
+        let sysroot = if let Ok(path) = env::var("XBUILD_SYSROOT_PATH") {
+            path
+        } else {
+            format!("{}", home.display())
+        };
         if env::var_os("XBUILD_ALLOW_SYSROOT_SPACES").is_none() && sysroot.contains(" ") {
             return Err(format!("Sysroot must not contain spaces!\n\
             See issue https://github.com/rust-lang/cargo/issues/6139\n\n\


### PR DESCRIPTION
This is useful for example when the default sysroot path contains spaces (see #32).