### PR TITLE
Fix the new XBUILD_SYSROOT_PATH environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Fix an issue with new `XBUILD_SYSROOT_PATH` environment variable ([#34](https://github.com/rust-osdev/cargo-xbuild/pull/34))
+
 ## [0.5.10] - 2019-05-31
 
 - Error when sysroot contains spaces ([#32](https://github.com/rust-osdev/cargo-xbuild/pull/32))

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -43,11 +43,7 @@ impl Rustflags {
 
     /// Stringifies these flags for Xargo consumption
     pub fn for_xargo(&self, home: &Home) -> Result<String> {
-        let sysroot = if let Ok(path) = env::var("XBUILD_SYSROOT_PATH") {
-            path
-        } else {
-            format!("{}", home.display())
-        };
+        let sysroot = format!("{}", home.display());
         if env::var_os("XBUILD_ALLOW_SYSROOT_SPACES").is_none() && sysroot.contains(" ") {
             return Err(format!("Sysroot must not contain spaces!\n\
             See issue https://github.com/rust-lang/cargo/issues/6139\n\n\

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -3,6 +3,7 @@ use std::mem;
 use std::path::Path;
 use std::path::{Display, PathBuf};
 use std::process::{Command, ExitStatus};
+use std::env;
 
 use rustc_version::VersionMeta;
 
@@ -72,8 +73,13 @@ impl Home {
 }
 
 pub fn home(root: &Path, config: &Config) -> Result<Home> {
-    let mut path = PathBuf::from(root);
-    path.push(&config.sysroot_path);
+    let path = if let Ok(path) = env::var("XBUILD_SYSROOT_PATH") {
+        PathBuf::from(path)
+    } else {
+        let mut path = PathBuf::from(root);
+        path.push(&config.sysroot_path);
+        path
+    };
 
     Ok(Home {
         path: Filesystem::new(path),


### PR DESCRIPTION
The variable was added in an invalid way in #33, so that it was only used in RUSTFLAGS but not for building the sysroot. This PR fixes this.