### PR TITLE
Add xdoc command

### DIFF
--- a/src/bin/cargo-xdoc.rs
+++ b/src/bin/cargo-xdoc.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("doc");
+}

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -32,8 +32,10 @@ pub fn run(
     let flags = rustflags.for_xargo(home)?;
     if verbose {
         writeln!(io::stderr(), "+ RUSTFLAGS={:?}", flags).ok();
+        writeln!(io::stderr(), "+ RUSTDOCFLAGS={:?}", flags).ok();
     }
-    cmd.env("RUSTFLAGS", flags);
+    cmd.env("RUSTFLAGS", &flags);
+    cmd.env("RUSTDOCFLAGS", &flags);
 
     let locks = (home.lock_ro(&meta.host), home.lock_ro(cmode.triple()));
 


### PR DESCRIPTION
By setting `RUSTDOCFLAGS` in addition to `RUSTFLAGS`, this patch allows `rustdoc` to inherit the modified sysroot. Closes #38.

(Figured I'd log `RUSTDOCFLAGS` in verbose mode too, in case future versions set it to something different than `RUSTFLAGS`, and since it's, well, verbose mode. Additionally, passing a reference to `Command:env` is totally equivalent to passing an owned string. Pretty minor patch.)