### PR TITLE
Don't append a `--sysroot` argument to `RUSTFLAGS` if it already contains one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Don't append a `--sysroot` argument to `RUSTFLAGS` if it already contains one ([#40](https://github.com/rust-osdev/cargo-xbuild/pull/40))
+
 ## [v0.5.13] - 2019-07-09
 
 - Add `cargo xdoc` command for invoking `cargo doc` ([#39](https://github.com/rust-osdev/cargo-xbuild/pull/39)).

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -52,8 +52,10 @@ impl Rustflags {
             environment variable.", sysroot).into());
         }
         let mut flags = self.flags.clone();
-        flags.push("--sysroot".to_owned());
-        flags.push(sysroot);
+        if !flags.contains(&String::from("--sysroot")) {
+            flags.push("--sysroot".to_owned());
+            flags.push(sysroot);
+        }
         Ok(flags.join(" "))
     }
 }


### PR DESCRIPTION
Appending the flag a second time leads to a "Option 'sysroot' given more than once" error.

This problem occurs because the user might set the `RUSTFLAGS` environment manually, for example for [getting RLS to work](https://github.com/phil-opp/blog_os/issues/403#issuecomment-510145328).