### PR TITLE
Add xb, xt, xc, and xr subcommands

### DIFF
--- a/src/bin/cargo-xb.rs
+++ b/src/bin/cargo-xb.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("b");
+}

--- a/src/bin/cargo-xc.rs
+++ b/src/bin/cargo-xc.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("c");
+}

--- a/src/bin/cargo-xr.rs
+++ b/src/bin/cargo-xr.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("r");
+}

--- a/src/bin/cargo-xt.rs
+++ b/src/bin/cargo-xt.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("t");
+}


### PR DESCRIPTION
I've added these as separate binaries, since it requires the least amount of configuration and retains the ease of adding new subcommands. I had to change the "check if this was invoked as a cargo subcommand" logic a little to make it actually work when invoked as e.g. `cargo xc`.

Closes #41.