### PR TITLE
Add `--quiet` flag that suppresses "waiting for file lock" message

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,10 @@ impl Args {
         self.manifest_path.as_ref().map(|s| &**s)
     }
 
+    pub fn quiet(&self) -> bool {
+        self.all.iter().any(|a| a == "--quiet" || a == "-q")
+    }
+
     pub fn verbose(&self) -> bool {
         self.all
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,7 @@ fn run(command_name: &str) -> Result<Option<ExitStatus>> {
 
 fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
     let verbose = args.verbose();
+    let quiet = args.quiet();
     let meta = rustc::version();
     let cd = CurrentDirectory::get()?;
     let config = cargo::config()?;
@@ -207,7 +208,7 @@ fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
     }
 
     if let Some(cmode) = cmode {
-        let home = xargo::home(root, &crate_config)?;
+        let home = xargo::home(root, &crate_config, quiet)?;
         let rustflags = cargo::rustflags(config.as_ref(), cmode.triple())?;
 
         sysroot::update(

--- a/src/xargo.rs
+++ b/src/xargo.rs
@@ -74,7 +74,7 @@ impl Home {
     }
 }
 
-pub fn home(root: &Path, config: &Config) -> Result<Home> {
+pub fn home(root: &Path, config: &Config, quiet: bool) -> Result<Home> {
     let path = if let Ok(path) = env::var("XBUILD_SYSROOT_PATH") {
         PathBuf::from(path)
     } else {
@@ -84,6 +84,6 @@ pub fn home(root: &Path, config: &Config) -> Result<Home> {
     };
 
     Ok(Home {
-        path: Filesystem::new(path),
+        path: Filesystem::new(path, quiet),
     })
 }


### PR DESCRIPTION
I think the "waiting for file lock" message shouldn't be printed unconditionally. In this PR, I've chosen to use the existing verbose flag to turn it on. An alternative would be to use a quiet flag, just as cargo does, to turn it off. I'm not sure what's better.

The reason I ran into this is that I'm using the ninja build system which updates a single line on the console to show the executing commands. That is, only errors create newlines and stay visible. Therefore, I'm passing "-q" to cargo, but unfortunately this get's ignored by cargo-xbuild.

_Edit(phil-opp):_ We decided to add a `--quiet` flag instead of using the existing `--verbose` flag.