### PR TITLE
Print a warning when building for the host target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Print a warning when building for the host system because this is often unintended.
+    - Building for the host system will also cause errors in build scripts of dependencies, which try to use the standard library. The reason is that [cargo applies the `RUSTFLAGS` environment variable also to build scripts in native compilation mode](https://github.com/rust-lang/cargo/blob/d9ff5762fe2a08d329fd869c6bb6b073796666cc/src/cargo/core/compiler/build_context/target_info.rs#L394-L395), thereby overriding the sysroot.
+
 ## [v0.5.15] - 2019-07-17
 
 - Add xb, xt, xc, and xr subcommands ([#42](https://github.com/rust-osdev/cargo-xbuild/pull/42))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,16 @@ fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
         }
     };
 
+    if let Some(CompilationMode::Native(_)) = cmode {
+        eprintln!(
+            "WARNING: You're currently building for the host system. This is likely an \
+            error and will cause build scripts of dependencies to break.\n\n\
+
+            To build for the target system either pass a `--target` argument or \
+            set the build.target configuration key in a `.cargo/config` file.\n",
+        );
+    }
+
     if let Some(cmode) = cmode {
         let home = xargo::home(root, &crate_config)?;
         let rustflags = cargo::rustflags(config.as_ref(), cmode.triple())?;


### PR DESCRIPTION
Building for the host system target is often not intended.

It will also cause 'can't find crate for `std`' errors in build scripts of dependencies, which try to use the standard library. The reason is that [cargo applies the `RUSTFLAGS` environment variable also to build scripts in native compilation mode](https://github.com/rust-lang/cargo/blob/d9ff5762fe2a08d329fd869c6bb6b073796666cc/src/cargo/core/compiler/build_context/target_info.rs#L394-L395), thereby overriding the sysroot.

This issue was reported in https://github.com/phil-opp/blog_os/issues/403#issuecomment-529538864.