### PR TITLE
Add support for publishing and installing cross compiled crates

### DIFF
--- a/src/bin/cargo-xinstall.rs
+++ b/src/bin/cargo-xinstall.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("install");
+}

--- a/src/bin/cargo-xpublish.rs
+++ b/src/bin/cargo-xpublish.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("publish");
+}


### PR DESCRIPTION
This is probably a niche use-case, but it is also a small PR. I plan to distribute an EFI application cross compiled with the `x86_64-unknown-uefi` target. But I would like to be able to give instructions to install and use these applications (via qemu) that are similar to installation of a normal binary available on cargo.io (i.e., you don't have to clone the source repo manually). So this PR adds an `xpublish` and `xinstall` command, tested using the `mythril` crate: https://crates.io/crates/mythril.