### PR TITLE
Support building sysroot on stable/beta

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,26 +156,18 @@ fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
     let crate_config = config::Config::from_metadata(&metadata)
         .map_err(|_| "parsing package.metadata.cargo-xbuild section failed")?;
 
-    // We can't build sysroot with stable or beta due to unstable features
     let sysroot = rustc::sysroot(verbose)?;
     let src = match meta.channel {
         Channel::Dev => rustc::Src::from_env().ok_or(
             "The XARGO_RUST_SRC env variable must be set and point to the \
              Rust source directory when working with the 'dev' channel",
         )?,
-        Channel::Nightly => {
+        Channel::Stable | Channel::Beta | Channel::Nightly => {
             if let Some(src) = rustc::Src::from_env() {
                 src
             } else {
                 sysroot.src()?
             }
-        }
-        Channel::Stable | Channel::Beta => {
-            bail!(
-                "The sysroot can't be built for the {:?} channel. \
-                 Switch to nightly.",
-                meta.channel
-            );
         }
     };
 

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -77,6 +77,7 @@ fn build_crate(
     let cargo = std::env::var("CARGO").unwrap_or("cargo".to_string());
     let mut cmd = Command::new(cargo);
     cmd.env_remove("RUSTFLAGS");
+    cmd.env("RUSTC_BOOTSTRAP", "1");
     cmd.env("CARGO_TARGET_DIR", &target_dir);
     cmd.env("__CARGO_DEFAULT_LIB_METADATA", "XARGO");
 


### PR DESCRIPTION
[`RUSTC_BOOTSTRAP=1`](https://github.com/rust-lang/rust/blob/ce361fb24f0896bf7d983549117cbe1f70f32dcf/src/bootstrap/bootstrap.py#L668) is what the Rust itself uses to build itself (because otherwise it wouldn't build on any channel other than nightly).

The justification that std can use unstable features is that it's always bundled with rustc, and whenever an unstable feature changes, std would be updated at the same time.

Since for sysroot we are literally building src from Rust, I think the same justification applies as well. 