### PR TITLE
Added new option to the configuration table (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ To configure `cargo-xbuild` create a `package.metadata.cargo-xbuild` table in yo
 [package.metadata.cargo-xbuild]
 memcpy = true
 sysroot_path = "target/sysroot"
+panic_immediate_abort = false
 ```
 
 - The `memcpy` flag defines whether the `mem` feature of the `compiler_builtins` crate should be activated. Turning this flag off allows to specify own versions of the `memcpy`, `memset` etc. functions.
 - The `sysroot_path` flag specifies the directory where the sysroot should be placed.
+- The `panic_immediate_abort` flag specifies whether the `panic_immediate_abort` feature the of `core` crate should be defined.
 
 ### Environment Variables
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,12 +6,14 @@ use std::path::PathBuf;
 pub struct Config {
     pub memcpy: bool,
     pub sysroot_path: PathBuf,
+    pub panic_immediate_abort: bool,
 }
 
 #[derive(Debug, Deserialize, Default)]
 struct ParseConfig {
     pub memcpy: Option<bool>,
     pub sysroot_path: Option<String>,
+    pub panic_immediate_abort: Option<bool>,
 }
 
 impl Config {
@@ -28,6 +30,7 @@ impl Config {
         Ok(Config {
             memcpy: config.memcpy.unwrap_or(true),
             sysroot_path: PathBuf::from(config.sysroot_path.unwrap_or("target/sysroot".into())),
+            panic_immediate_abort: config.panic_immediate_abort.unwrap_or(false),
         })
     }
 }

--- a/src/help.txt
+++ b/src/help.txt
@@ -17,5 +17,6 @@ CONFIGURATION:
     [package.metadata.cargo-xbuild]
     memcpy = true
     sysroot_path = "target/sysroot"
+    panic_immediate_abort = false
 
     See README.md for a description of these flags.

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -162,6 +162,10 @@ version = "0.1.0"
         src.path().join("libcore").display()
     ));
 
+    if config.panic_immediate_abort {
+        stoml.push_str("features = ['panic_immediate_abort']\n");
+    }
+
     stoml.push_str("[patch.crates-io.rustc-std-workspace-core]\n");
     stoml.push_str(&format!(
         "path = '{}'\n",


### PR DESCRIPTION
Added the option `panic_immediate_abort` to the configuration table. If this option is set to `true`, then the `core` crate will be compiled with the feature `panic_immediate_abort`. This new option is derived from #55.

Fixes #55.