### PR TITLE
Pick up xbuild config from workspace manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 name = "cargo-xbuild"
 version = "0.5.22"
 dependencies = [
- "cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -41,10 +41,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.5.8"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -64,14 +63,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "error-chain"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -368,10 +359,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
-"checksum cargo_metadata 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1efca0b863ca03ed4c109fb1c55e0bc4bbeb221d3e103d86251046b06a526bd0"
+"checksum cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "46e3374c604fb39d1a2f35ed5e4a4e30e60d01fab49446e08f1b3e9a90aef202"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "318cb3c71ee4cdea69fdc9e15c173b245ed6063e1709029e8fd32525a881120f"
 "checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ version = "0.7.2"
 default-features = false
 
 [dependencies.cargo_metadata]
-version = "0.5.5"
+version = "0.9.1"
 default-features = false
 
 [dev-dependencies]
@@ -40,4 +40,4 @@ version = "0.3.6"
 
 [features]
 dev = []
-backtrace = ["error-chain/backtrace", "cargo_metadata/backtrace"]
+backtrace = ["error-chain/backtrace"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,8 +150,13 @@ fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
     let cd = CurrentDirectory::get()?;
     let config = cargo::config()?;
 
-    let metadata =
-        cargo_metadata::metadata(args.manifest_path()).expect("cargo metadata invocation failed");
+    let mut cmd = cargo_metadata::MetadataCommand::new();
+    if let Some(manifest_path) = args.manifest_path() {
+        cmd.manifest_path(manifest_path);
+    }
+    let metadata = cmd
+        .exec()
+        .expect("cargo metadata invocation failed");
     let root = Path::new(&metadata.workspace_root);
     let crate_config = config::Config::from_metadata(&metadata)
         .map_err(|_| "parsing package.metadata.cargo-xbuild section failed")?;


### PR DESCRIPTION
If the Cargo.toml defines a workspace, then the `[package.metadata.cargo-xbuild]` may not be picked up, and the default configuration will be used silently . 

This is because the current code assumes that the root package is the first one: https://github.com/rust-osdev/cargo-xbuild/blob/master/src/config.rs#L21.

This PR infers the root package via `metadata.resolve`. It also updates `cargo-metadata` to the most recent version.

Fixes #54 