### PR TITLE
Make `fn build` and `Args` public to enable use as lib

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,10 @@ pub struct Args {
 }
 
 impl Args {
+    pub fn new(all: Vec<String>, target: Option<String>, manifest_path: Option<PathBuf>) -> Self {
+        Args { all, target, manifest_path }
+    }
+
     pub fn all(&self) -> &[String] {
         &self.all
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,8 +8,18 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn new(all: Vec<String>, target: Option<String>, manifest_path: Option<PathBuf>) -> Self {
-        Args { all, target, manifest_path }
+    pub fn new<A, S, T, P>(all: A, target: Option<T>, manifest_path: Option<P>) -> Self
+    where
+        A: IntoIterator<Item = S>,
+        S: AsRef<str>,
+        T: Into<String>,
+        P: Into<PathBuf>,
+    {
+        Args {
+            all: all.into_iter().map(|s| s.as_ref().to_string()).collect(),
+            target: target.map(Into::into),
+            manifest_path: manifest_path.map(Into::into)
+        }
     }
 
     pub fn all(&self) -> &[String] {
@@ -50,7 +60,7 @@ pub fn args(command_name: &str) -> Result<(Command, Args), String> {
         _ => Command::Build,
     };
 
-    let mut target = None;
+    let mut target: Option<String> = None;
     let mut manifest_path = None;
     {
         let mut args = all.iter();
@@ -68,11 +78,7 @@ pub fn args(command_name: &str) -> Result<(Command, Args), String> {
         }
     }
 
-    let args = Args {
-        all: all,
-        target: target,
-        manifest_path: manifest_path.as_ref().map(PathBuf::from),
-    };
+    let args = Args::new(all, target, manifest_path);
     Ok((command, args))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ fn run(command_name: &str) -> Result<Option<ExitStatus>> {
     }
 }
 
-fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
+pub fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
     let verbose = args.verbose();
     let quiet = args.quiet();
     let meta = rustc::version();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ mod sysroot;
 mod util;
 mod xargo;
 
+pub use cli::Args;
+
 // We use a different sysroot for Native compilation to avoid file locking
 //
 // Cross compilation requires `lib/rustlib/$HOST` to match `rustc`'s sysroot,


### PR DESCRIPTION
Closes #58.

Calling `build` directly allows use of `xbuild` as a library rather than needing to invoke it. This means for my build tool the user is not required to install `xbuild`. See https://github.com/paritytech/cargo-contract/pull/33/files#diff-ddd98095116f321c0aff2844e8cd3c55R106. 