### PR TITLE
Fix: Not all projects have a root package 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -38,7 +38,7 @@ impl Config {
         let config = match crate_metadata {
             Some(json) => {
                 serde_json::from_value(json.clone())
-                    .map_err(|_| "parsing package.metadata.cargo-xbuild section failed")?
+                    .map_err(|e| format!("parsing package.metadata.cargo-xbuild section failed: {}", e))?
             }
             None => ParseConfig::default(),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@ pub fn build(args: cli::Args, command_name: &str) -> Result<ExitStatus> {
         .expect("cargo metadata invocation failed");
     let root = Path::new(&metadata.workspace_root);
     let crate_config = config::Config::from_metadata(&metadata)
-        .map_err(|_| "parsing package.metadata.cargo-xbuild section failed")?;
+        .map_err(|e| format!("reading package.metadata.cargo-xbuild section failed: {}", e))?;
 
     // We can't build sysroot with stable or beta due to unstable features
     let sysroot = rustc::sysroot(verbose)?;


### PR DESCRIPTION
Since #57, we try to read the config from the root package of the workspace, instead of just defaulting to the first package. The problem with this is that the new code assumes that there is always a root _package_ in the workspace, which is not true when only a [_virtual manifest_](https://doc.rust-lang.org/cargo/reference/manifest.html#virtual-manifest) is used at the root.

With this pull request we no longer error for such workspaces. Instead, we emit a warning that no cargo-xbuild configuration is applied and use the default config. This isn't optimal, but there is no canoncial place to read the config from and I can't think of a better approach.

To ensure that future config related errors are easier to debug, this pull request also prints the underlying cause for config load errors.

Fixes #60 

