### PR TITLE
Improvements to args and config for lib usage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,19 +29,23 @@ impl Args {
         S: AsRef<str>,
     {
         // check for duplicates of the explicit args
-        let explicit_args = ["--target", "--manifest-path", "--verbose", "--quiet"];
         let other_args = other_args
             .into_iter()
             .map(|a| a.as_ref().to_string())
             .collect::<Vec<_>>();
 
+        let explicit_args = ["--target", "--manifest-path", "--verbose", "--quiet"];
         let duplicates = other_args
             .iter()
-            .filter(|a| explicit_args.iter().any(|ea| a.starts_with(ea)))
+            .filter(|a| {
+                explicit_args
+                    .iter()
+                    .any(|ea| a == ea || a.starts_with(&format!("{}=", ea)))
+            })
             .collect::<Vec<_>>();
         if !duplicates.is_empty() {
             return Err(
-                format!("The following args should be passed explicitly: '{:?}'", duplicates)
+                format!("The following args should be passed explicitly: {:?}", duplicates)
             )
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ impl Args {
         target: Option<T>,
         manifest_path: Option<P>,
         verbosity: Option<Verbosity>,
-        other_args: A
+        other_args: A,
     ) -> Result<Self, String>
     where
         T: Into<String> + Clone,
@@ -44,9 +44,10 @@ impl Args {
             })
             .collect::<Vec<_>>();
         if !duplicates.is_empty() {
-            return Err(
-                format!("The following args should be passed explicitly: {:?}", duplicates)
-            )
+            return Err(format!(
+                "The following args should be passed explicitly: {:?}",
+                duplicates
+            ));
         }
 
         // add the explicitly specified args to `all` which will be passed on to `cargo`
@@ -55,7 +56,10 @@ impl Args {
             all.push(format!("--target={}", target.into()))
         }
         if let Some(ref manifest_path) = manifest_path {
-            all.push(format!("--manifest-path={}", manifest_path.as_ref().to_string_lossy()))
+            all.push(format!(
+                "--manifest-path={}",
+                manifest_path.as_ref().to_string_lossy()
+            ))
         }
         if let Some(ref verbosity) = verbosity {
             match verbosity {
@@ -78,7 +82,10 @@ impl Args {
         A: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        let all = all.into_iter().map(|a| a.as_ref().to_string()).collect::<Vec<_>>();
+        let all = all
+            .into_iter()
+            .map(|a| a.as_ref().to_string())
+            .collect::<Vec<_>>();
 
         let mut target: Option<String> = None;
         let mut manifest_path = None;
@@ -98,13 +105,13 @@ impl Args {
                 }
                 if arg == "--verbose" || arg == "-v" || arg == "-vv" {
                     if let Some(Verbosity::Quiet) = verbosity {
-                        return Err("cannot set both --verbose and --quiet".into())
+                        return Err("cannot set both --verbose and --quiet".into());
                     }
                     verbosity = Some(Verbosity::Verbose)
                 }
                 if arg == "--quiet" || arg == "-q" {
                     if let Some(Verbosity::Verbose) = verbosity {
-                        return Err("cannot set both --verbose and --quiet".into())
+                        return Err("cannot set both --verbose and --quiet".into());
                     }
                     verbosity = Some(Verbosity::Quiet)
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,12 +28,12 @@ impl Args {
         A: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        // check for duplicates of the explicit args
         let other_args = other_args
             .into_iter()
             .map(|a| a.as_ref().to_string())
             .collect::<Vec<_>>();
 
+        // check for duplicates of the explicit args
         let explicit_args = ["--target", "--manifest-path", "--verbose", "--quiet"];
         let duplicates = other_args
             .iter()
@@ -50,7 +50,7 @@ impl Args {
             ));
         }
 
-        // add the explicitly specified args to `all` which will be passed on to `cargo`
+        // add the explicit args to `all` which will be passed on to `cargo`
         let mut all = other_args;
         if let Some(target) = target.clone() {
             all.push(format!("--target={}", target.into()))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,21 +5,114 @@ pub struct Args {
     all: Vec<String>,
     target: Option<String>,
     manifest_path: Option<PathBuf>,
+    verbosity: Option<Verbosity>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum Verbosity {
+    Quiet,
+    Verbose,
 }
 
 impl Args {
-    pub fn new<A, S, T, P>(all: A, target: Option<T>, manifest_path: Option<P>) -> Self
+    /// Create args explicitly, with other args passed unchanged to cargo invocation
+    pub fn new<T, P, A, S>(
+        target: Option<T>,
+        manifest_path: Option<P>,
+        verbosity: Option<Verbosity>,
+        other_args: A
+    ) -> Result<Self, String>
+    where
+        T: Into<String> + Clone,
+        P: AsRef<Path>,
+        A: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        // check for duplicates of the explicit args
+        let explicit_args = ["--target", "--manifest-path", "--verbose", "--quiet"];
+        let other_args = other_args
+            .into_iter()
+            .map(|a| a.as_ref().to_string())
+            .collect::<Vec<_>>();
+
+        let duplicates = other_args
+            .iter()
+            .filter(|a| explicit_args.iter().any(|ea| a.starts_with(ea)))
+            .collect::<Vec<_>>();
+        if !duplicates.is_empty() {
+            return Err(
+                format!("The following args should be passed explicitly: '{:?}'", duplicates)
+            )
+        }
+
+        // add the explicitly specified args to `all` which will be passed on to `cargo`
+        let mut all = other_args;
+        if let Some(target) = target.clone() {
+            all.push(format!("--target={}", target.into()))
+        }
+        if let Some(ref manifest_path) = manifest_path {
+            all.push(format!("--manifest-path={}", manifest_path.as_ref().to_string_lossy()))
+        }
+        if let Some(ref verbosity) = verbosity {
+            match verbosity {
+                Verbosity::Verbose => all.push("--verbose".into()),
+                Verbosity::Quiet => all.push("--quiet".into()),
+            }
+        }
+
+        Ok(Args {
+            all,
+            target: target.map(Into::into),
+            manifest_path: manifest_path.map(|p| p.as_ref().into()),
+            verbosity,
+        })
+    }
+
+    /// Parse raw args from command line
+    pub fn from_raw<A, S>(all: A) -> Result<Self, String>
     where
         A: IntoIterator<Item = S>,
         S: AsRef<str>,
-        T: Into<String>,
-        P: Into<PathBuf>,
     {
-        Args {
-            all: all.into_iter().map(|s| s.as_ref().to_string()).collect(),
-            target: target.map(Into::into),
-            manifest_path: manifest_path.map(Into::into)
+        let all = all.into_iter().map(|a| a.as_ref().to_string()).collect::<Vec<_>>();
+
+        let mut target: Option<String> = None;
+        let mut manifest_path = None;
+        let mut verbosity = None;
+        {
+            let mut args = all.iter();
+            while let Some(arg) = args.next() {
+                if arg == "--target" {
+                    target = args.next().map(|s| s.to_owned());
+                } else if arg.starts_with("--target=") {
+                    target = arg.splitn(2, '=').nth(1).map(|s| s.to_owned());
+                }
+                if arg == "--manifest-path" {
+                    manifest_path = args.next().map(|s| s.to_owned());
+                } else if arg.starts_with("--manifest-path=") {
+                    manifest_path = arg.splitn(2, '=').nth(1).map(|s| s.to_owned());
+                }
+                if arg == "--verbose" || arg == "-v" || arg == "-vv" {
+                    if let Some(Verbosity::Quiet) = verbosity {
+                        return Err("cannot set both --verbose and --quiet".into())
+                    }
+                    verbosity = Some(Verbosity::Verbose)
+                }
+                if arg == "--quiet" || arg == "-q" {
+                    if let Some(Verbosity::Verbose) = verbosity {
+                        return Err("cannot set both --verbose and --quiet".into())
+                    }
+                    verbosity = Some(Verbosity::Quiet)
+                }
+            }
         }
+
+        Ok(Args {
+            all,
+            target: target.map(Into::into),
+            manifest_path: manifest_path.map(Into::into),
+            verbosity,
+        })
     }
 
     pub fn all(&self) -> &[String] {
@@ -35,13 +128,11 @@ impl Args {
     }
 
     pub fn quiet(&self) -> bool {
-        self.all.iter().any(|a| a == "--quiet" || a == "-q")
+        self.verbosity == Some(Verbosity::Quiet)
     }
 
     pub fn verbose(&self) -> bool {
-        self.all
-            .iter()
-            .any(|a| a == "--verbose" || a == "-v" || a == "-vv")
+        self.verbosity == Some(Verbosity::Verbose)
     }
 }
 
@@ -60,25 +151,7 @@ pub fn args(command_name: &str) -> Result<(Command, Args), String> {
         _ => Command::Build,
     };
 
-    let mut target: Option<String> = None;
-    let mut manifest_path = None;
-    {
-        let mut args = all.iter();
-        while let Some(arg) = args.next() {
-            if arg == "--target" {
-                target = args.next().map(|s| s.to_owned());
-            } else if arg.starts_with("--target=") {
-                target = arg.splitn(2, '=').nth(1).map(|s| s.to_owned());
-            }
-            if arg == "--manifest-path" {
-                manifest_path = args.next().map(|s| s.to_owned());
-            } else if arg.starts_with("--manifest-path=") {
-                manifest_path = arg.splitn(2, '=').nth(1).map(|s| s.to_owned());
-            }
-        }
-    }
-
-    let args = Args::new(all, target, manifest_path);
+    let args = Args::from_raw(all)?;
     Ok((command, args))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod util;
 mod xargo;
 
 pub use cli::{Args, Verbosity};
+pub use config::Config;
 
 // We use a different sysroot for Native compilation to avoid file locking
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,7 @@ fn run(command_name: &str) -> Result<Option<ExitStatus>> {
 ///
 /// If `crate_config` is provided it will override the values in the `Cargo.toml`.
 /// Otherwise the config specified in the `[package.metadata.cargo-xbuild section]` will be used.
-pub fn build(args: cli::Args, command_name: &str, crate_config: Option<config::Config>) -> Result<ExitStatus> {
+pub fn build(args: Args, command_name: &str, crate_config: Option<Config>) -> Result<ExitStatus> {
     let verbose = args.verbose();
     let quiet = args.quiet();
     let meta = rustc::version();
@@ -169,7 +169,7 @@ pub fn build(args: cli::Args, command_name: &str, crate_config: Option<config::C
 
     // Fall back to manifest if config not explicitly specified
     let crate_config = crate_config.map(Ok).unwrap_or_else(|| {
-        config::Config::from_metadata(&metadata)
+        Config::from_metadata(&metadata)
             .map_err(|e| format!("reading package.metadata.cargo-xbuild section failed: {}", e))
     })?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod sysroot;
 mod util;
 mod xargo;
 
-pub use cli::Args;
+pub use cli::{Args, Verbosity};
 
 // We use a different sysroot for Native compilation to avoid file locking
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ fn run(command_name: &str) -> Result<Option<ExitStatus>> {
 /// Execute a cargo command with cross compiled sysroot crates for custom targets.
 ///
 /// If `crate_config` is provided it will override the values in the `Cargo.toml`.
-/// Otherwise the config specified in the `[package.metadata.cargo-xbuild section]` will be used.
+/// Otherwise the config specified in the `[package.metadata.cargo-xbuild]` section will be used.
 pub fn build(args: Args, command_name: &str, crate_config: Option<Config>) -> Result<ExitStatus> {
     let verbose = args.verbose();
     let quiet = args.quiet();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,15 +162,17 @@ pub fn build(args: Args, command_name: &str, crate_config: Option<Config>) -> Re
         cmd.manifest_path(manifest_path);
     }
 
-    let metadata = cmd
-        .exec()
-        .expect("cargo metadata invocation failed");
+    let metadata = cmd.exec().expect("cargo metadata invocation failed");
     let root = Path::new(&metadata.workspace_root);
 
     // Fall back to manifest if config not explicitly specified
     let crate_config = crate_config.map(Ok).unwrap_or_else(|| {
-        Config::from_metadata(&metadata)
-            .map_err(|e| format!("reading package.metadata.cargo-xbuild section failed: {}", e))
+        Config::from_metadata(&metadata).map_err(|e| {
+            format!(
+                "reading package.metadata.cargo-xbuild section failed: {}",
+                e
+            )
+        })
     })?;
 
     // We can't build sysroot with stable or beta due to unstable features


### PR DESCRIPTION
This PR introduces an optional `config` parameter to the public `fn build`. This allows passing explicit config when using `xbuild` as a library (#58), which would otherwise require appending the config section to the `Cargo.toml`. If `None` is passed then it will attempt to resolve from the config file.

A second improvement is a new constructor for `Args`, which will add the explicitly specified args to the list of all args. This set of args is passed through to the internal invocation of `cargo`. Previously the constructor accepted the explicit args but they were not added to the list of all args.