### PR TITLE
Add `cargo xfix` command

### DIFF
--- a/src/bin/cargo-xfix.rs
+++ b/src/bin/cargo-xfix.rs
@@ -1,0 +1,5 @@
+extern crate xargo_lib;
+
+pub fn main() {
+    xargo_lib::main_common("fix");
+}


### PR DESCRIPTION
Add `cargo xfix` command as described in issue #63.

Tested locally by running `cargo install` then `cargo xfix ...`.