### PR TITLE
Pass -Cembed-bitcode=yes instead of -Clinker-plugin-lto for sysroot build

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -84,7 +84,7 @@ fn build_crate(
 
     let cargo = std::env::var("CARGO").unwrap_or("cargo".to_string());
     let mut cmd = Command::new(cargo);
-    cmd.env("RUSTFLAGS", "-Clinker-plugin-lto");
+    cmd.env("RUSTFLAGS", "-Cembed-bitcode=yes");
     cmd.env("CARGO_TARGET_DIR", &target_dir);
     cmd.env("__CARGO_DEFAULT_LIB_METADATA", "XARGO");
 


### PR DESCRIPTION
This is the same approach that rustc bootstrap uses: https://github.com/rust-lang/rust/blob/a2e0b48e6eef854521d3199ee9e327aab298f071/src/bootstrap/compile.rs#L235-L245

See https://github.com/japaric/xargo/issues/292 and #69 for more information.