### PR TITLE
Don't print warning about missing root package in quiet mode.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ struct ParseConfig {
 }
 
 impl Config {
-    pub fn from_metadata(metadata: &cargo_metadata::Metadata) -> Result<Config> {
+    pub fn from_metadata(metadata: &cargo_metadata::Metadata, quiet: bool) -> Result<Config> {
         let root_manifest = metadata.workspace_root.join("Cargo.toml");
         let root_package = metadata
             .packages
@@ -49,9 +49,11 @@ impl Config {
                 //
                 // So we can't read the config for such projects. To make this transparent to
                 // the user, we print a warning.
-                eprintln!(
-                    "WARNING: There is no root package to read the cargo-xbuild config from."
-                );
+                if !quiet {
+                    eprintln!(
+                        "WARNING: There is no root package to read the cargo-xbuild config from."
+                    );
+                }
                 // There is no config to read, so we use default options
                 ParseConfig::default()
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ pub fn build(args: Args, command_name: &str, crate_config: Option<Config>) -> Re
 
     // Fall back to manifest if config not explicitly specified
     let crate_config = crate_config.map(Ok).unwrap_or_else(|| {
-        Config::from_metadata(&metadata).map_err(|e| {
+        Config::from_metadata(&metadata, args.quiet()).map_err(|e| {
             format!(
                 "reading package.metadata.cargo-xbuild section failed: {}",
                 e


### PR DESCRIPTION
There does not seem to be a way to avoid that warning if a workspace is used. So, allow the user to disable the warning by passing --quiet to cargo-xbuild.