### PR TITLE
Propagate `cargo-features` from project's Cargo.toml

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -233,6 +233,19 @@ impl<'t> fmt::Display for Profile<'t> {
     }
 }
 
+pub struct Features<'a> {
+    array: &'a Value,
+}
+
+impl<'a> fmt::Display for Features<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut map = toml::map::Map::new();
+        map.insert("cargo-features".to_owned(), self.array.clone());
+
+        fmt::Display::fmt(&Value::Table(map), f)
+    }
+}
+
 pub struct Toml {
     table: Value,
 }
@@ -244,6 +257,12 @@ impl Toml {
             .get("profile")
             .and_then(|v| v.get("release"))
             .map(|t| Profile { table: t })
+    }
+
+    pub fn features(&self) -> Option<Features> {
+        self.table
+            .get("cargo-features")
+            .map(|a| Features { array: a })
     }
 }
 

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -76,6 +76,10 @@ fn build_crate(
 
     let target_dir = td.join("target");
 
+    if let Some(features) = ctoml.features() {
+        stoml.insert_str(0, &features.to_string())
+    }
+
     if let Some(profile) = ctoml.profile() {
         stoml.push_str(&profile.to_string())
     }


### PR DESCRIPTION
The `[profile.release]` section of the project's Cargo.toml is propagated into the xbuild, but may rely on Cargo features that require explicit enabling.  This PR also propagates any `cargo-features` from the project's Cargo.toml into the xbuild.

(I encountered this case when attempting to use [Cargo's new `strip` feature](https://github.com/rust-lang/cargo/pull/8246)).