### PR TITLE
Update cargo-xbuild to new rust directory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In addition to the above configuration keys, `cargo-xbuild` can be also configur
 If you want to use a local Rust source instead of `rust-src` rustup component, you can set the `XARGO_RUST_SRC` environment variable.
 
 ```
-# The source of the `core` crate must be in `$XARGO_RUST_SRC/libcore`
+# The source of the `core` crate must be in `$XARGO_RUST_SRC/core`
 $ export XARGO_RUST_SRC=/path/to/rust/src
 
 $ cargo xbuild --target msp430-none-elf.json

--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -177,7 +177,7 @@ version = "0.1.0"
     stoml.push_str("[dependencies.core]\n");
     stoml.push_str(&format!(
         "path = '{}'\n",
-        src.path().join("libcore").display()
+        src.path().join("core").display()
     ));
 
     if config.panic_immediate_abort {
@@ -187,10 +187,10 @@ version = "0.1.0"
     stoml.push_str("[patch.crates-io.rustc-std-workspace-core]\n");
     stoml.push_str(&format!(
         "path = '{}'\n",
-        src.path().join("tools/rustc-std-workspace-core").display()
+        src.path().join("rustc-std-workspace-core").display()
     ));
 
-    let path = src.path().join("liballoc/lib.rs").display().to_string();
+    let path = src.path().join("alloc/src/lib.rs").display().to_string();
     let mut map = Table::new();
     let mut lib = Table::new();
     lib.insert("name".to_owned(), Value::String("alloc".to_owned()));


### PR DESCRIPTION
This updates `cargo-xbuild` to the new directory layout of `rust-src` component, which was introduced in https://github.com/rust-lang/rust/pull/73265.

Since this only works with nightlies newer than 2020-07-30, this is technically a **breaking change**.