### PR TITLE
Remove fs2 dependency for broader platform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,6 @@ version = "0.6.0"
 dependencies = [
  "cargo_metadata 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -80,15 +79,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -384,7 +374,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum error-chain 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
-"checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.6.0"
 name = "xargo_lib"
 
 [dependencies]
-fs2 = "0.4.1"
 libc = "0.2.18"
 rustc_version = "0.2"
 serde = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 extern crate cargo_metadata;
 #[macro_use]
 extern crate error_chain;
-extern crate fs2;
 #[cfg(any(
     all(target_os = "linux", not(target_env = "musl")),
     target_os = "macos"


### PR DESCRIPTION
The use of [fs2](https://crates.io/crates/fs2) for file locking limits the platforms where cargo-xbuild can be built/installed.  Upstream cargo [was updated](https://github.com/rust-lang/cargo/commit/c04a87c1924246adef44c88bb64e5c7a8c60b823#diff-d4282c27d6736be951b98f456f02960a) to make the locking calls itself, as `fs2` is effectively unmaintained (and thus not merging patches to support new platforms).  This PR replicates that change, so cargo-xbuild is effectively freed of the platform constraints of `fs2`.

Thanks