### PR TITLE
Add GitHub Action for cargo-build check

### DIFF
--- a/.github/workflows/cargo-build.yaml
+++ b/.github/workflows/cargo-build.yaml
@@ -1,0 +1,26 @@
+name: CI Build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: cargo build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Run `cargo build`
+        uses: actions-rs/cargo@v1
+        with:
+          command: build


### PR DESCRIPTION
Running `cargo build` on Linux, MacOS, and Windows should help catch build issues at least.