### PR TITLE
Fix winapi issues from flock() rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ default-features = false
 version = "0.9.1"
 default-features = false
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winerror", "fileapi", "winbase", "std"] }
+
 [dev-dependencies]
 lazy_static = "1.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ extern crate serde_derive;
 extern crate tempfile;
 extern crate toml;
 extern crate walkdir;
+#[cfg(windows)]
+extern crate winapi;
 
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
This should fix the breakage on Windows from #91  

Sorry about the extra hassle.