### PR TITLE
Ensure copied Cargo.lock is writable

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -85,11 +85,25 @@ fn build_crate(
     }
 
     util::write(&td.join("Cargo.toml"), &stoml)?;
-    fs::copy(lockfile, &td.join("Cargo.lock")).with_context(|| {
+    let td_lockfile = &td.join("Cargo.lock");
+    fs::copy(lockfile, td_lockfile).with_context(|| {
         format!(
             "failed to copy Cargo.lock from `{}` to `{}`",
             lockfile.display(),
-            &td.join("Cargo.lock").display()
+            td_lockfile.display()
+        )
+    })?;
+    let mut perms = fs::metadata(&td_lockfile).with_context(|| {
+        format!(
+            "failed to retrieve permissions for `{}`",
+            td_lockfile.display()
+        )
+    })?.permissions();
+    perms.set_readonly(false);
+    fs::set_permissions(&td_lockfile, perms).with_context(|| {
+        format!(
+            "failed to set writable permission for `{}`",
+            td_lockfile.display()
         )
     })?;
     util::mkdir(&td.join("src"))?;


### PR DESCRIPTION
Updated from #96:
> If the path pointed to by XARGO_RUST_SRC contains read-only Cargo
> lockfiles, then xbuild fails because the copies it makes and attempts to
> modify are also read-only.