### PR TITLE
Don't panic on metadata errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,9 @@ pub fn build(args: Args, command_name: &str, crate_config: Option<Config>) -> Re
         cmd.manifest_path(manifest_path);
     }
 
-    let metadata = cmd.exec().expect("cargo metadata invocation failed");
+    let metadata = cmd
+        .exec()
+        .map_err(|e| anyhow!("cargo metadata invocation failed: {}", e))?;
     let root = Path::new(&metadata.workspace_root);
 
     // Fall back to manifest if config not explicitly specified


### PR DESCRIPTION
This `expect()` causes my cargo subcommand to panic when building a project with invalid Cargo.toml metadata. E.g. specifying a dependency that cannot be downloaded, or invalid TOML syntax.

Transforming the error into a string instead of panicking provides a much more readable error message, and potentially allows callers to handle the failure gracefully.

Before:

```
$ cargo n64 build --ipl3 ~/bin/CIC-NUS-6102.bin -- --package hello-ipl3font
    Building with cargo xbuild
thread 'main' panicked at 'cargo metadata invocation failed: CargoMetadata { stderr: "    Updating crates.io index\nerror: no matching package named `this-package-does-not-exist` found\nlocation searched: registry `https://github.com/rust-lang/crates.io-index`\nrequired by package `hello-ipl3font v0.1.0 (/Users/parasyte/projects/cargo-n64/examples/hello-ipl3font)`\n" }', /Users/parasyte/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-xbuild-0.6.3/src/lib.rs:145:31
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:

```
$ cargo n64 build --ipl3 ~/bin/CIC-NUS-6102.bin -- --package hello-ipl3font
    Building with cargo xbuild
error: xbuild error: cargo metadata invocation failed: Error during execution of `cargo metadata`:     Updating crates.io index
error: no matching package named `this-package-does-not-exist` found
location searched: registry `https://github.com/rust-lang/crates.io-index`
required by package `hello-ipl3font v0.1.0 (/Users/parasyte/projects/cargo-n64/examples/hello-ipl3font)`
```