### PR TITLE
Fix: The `alloc` crate uses the Rust 2021 edition now

### DIFF
--- a/src/sysroot.rs
+++ b/src/sysroot.rs
@@ -177,7 +177,7 @@ fn build_liballoc(
 authors = ["The Rust Project Developers"]
 name = "alloc"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies.compiler_builtins]
 version = "0.1.0"


### PR DESCRIPTION
The alloc library was switched to the 2021 edition in <https://github.com/rust-lang/rust/pull/92068>. However, it did not use any features of the new edition until PR <https://github.com/rust-lang/rust/pull/98103>, which relies on the newer closure capture mechanism. This commit fixes the build on the latest nightlies, which include that PR.

Fixes #104
